### PR TITLE
Rename tmpfile/tmpdir to tmp-file/tmp-dir

### DIFF
--- a/src/cpmcdaniel/boot_copy.clj
+++ b/src/cpmcdaniel/boot_copy.clj
@@ -19,7 +19,7 @@
       (let [in-files (->> fileset
                           output-files
                           (by-re matching)
-                          (map (juxt tmppath tmpfile)))]
+                          (map (juxt tmp-path tmp-file)))]
         (doseq [[path in-file] in-files]
           (let [out-file (doto (io/file out-dir path) io/make-parents)]
             (util/info "Copying %s to %s...\n" path out-dir)


### PR DESCRIPTION
Deprecation notice added by boot-clj/boot@9493ac6-- no further commits required to keep current with boot-clj/boot@4e97d7c (master)
