### PR TITLE
Add ignore to ignore files when copying

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ A simple `copy` task that allows boot builds to copy files from previous tasks i
 
 [](dependency)
 ```clojure
-[cpmcdaniel/boot-copy "1.0"] ;; latest release
+[cpmcdaniel/boot-copy "1.1"] ;; latest release
 ```
 [](/dependency)
 

--- a/build.boot
+++ b/build.boot
@@ -1,7 +1,7 @@
 (set-env!
  :source-paths #{"src"}
  :dependencies '[[adzerk/bootlaces "0.1.9" :scope "test"]
-                 [allgress/boot-tasks "0.2.2" :scope "test" :exclusions [commons-codec]]])
+                 [allgress/boot-tasks "0.2.3" :scope "test" :exclusions [commons-codec]]])
 
 
 (require '[adzerk.bootlaces :refer :all]

--- a/build.boot
+++ b/build.boot
@@ -1,10 +1,12 @@
 (set-env!
  :source-paths #{"src"}
- :dependencies '[[adzerk/bootlaces "0.1.9" :scope "test"]])
+ :dependencies '[[adzerk/bootlaces "0.1.9" :scope "test"]
+                 [allgress/boot-tasks "0.2.2" :scope "test" :exclusions [commons-codec]]])
 
 
 (require '[adzerk.bootlaces :refer :all]
-         '[cpmcdaniel.boot-copy :refer :all])
+         '[cpmcdaniel.boot-copy :refer :all]
+         '[allgress.boot-tasks :refer :all])
 
 (def +version+ "1.1")
 

--- a/build.boot
+++ b/build.boot
@@ -6,7 +6,7 @@
 (require '[adzerk.bootlaces :refer :all]
          '[cpmcdaniel.boot-copy :refer :all])
 
-(def +version+ "1.0")
+(def +version+ "1.1")
 
 (bootlaces! +version+)
 

--- a/src/cpmcdaniel/boot_copy.clj
+++ b/src/cpmcdaniel/boot_copy.clj
@@ -13,12 +13,14 @@
 
      $ boot build copy -m '\\.jar$' -o /home/foo/jars"
   [o output-dir PATH str     "The output directory path."
-   m matching REGEX #{regex} "The set of regexes matching paths to backup."]
+   m matching REGEX #{regex} "The set of regexes matching paths to backup."
+   i ignore REGEX #{regex}]
   (let [out-dir (io/file output-dir)]
     (with-pre-wrap fileset
       (let [in-files (->> fileset
                           output-files
                           (by-re matching)
+                          (not-by-re ignore)
                           (map (juxt tmppath tmpfile)))]
         (doseq [[path in-file] in-files]
           (let [out-file (doto (io/file out-dir path) io/make-parents)]


### PR DESCRIPTION
Adds the ability to ignore certain files/directories. Example use case: 

``` clojure
(task-options!
  copy {:output-dir "./public"
        :matching   #{#".*\.html"
                      #".*\.js"
                      #".*\.map"
                      #".*\.css"}
        :ignore     #{#"^(out|\/out)\/.*"}})
```
